### PR TITLE
Remove pandas dependecy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         "Programming Language :: Python :: 3"
     ],
     install_requires=[
-        "pandas",
         "requests"
     ]
 )

--- a/src/typegenie/api.py
+++ b/src/typegenie/api.py
@@ -2,7 +2,6 @@ import time
 from datetime import datetime, timezone
 from typing import List
 
-import pandas as pd
 from threading import Thread
 
 import requests
@@ -29,7 +28,7 @@ class AutoRenewThread(Thread):
     def run(self):
         while self._running:
             result = self.api.renew_token(inplace=True)
-            expires_at = pd.to_datetime(result['expires_at']).to_pydatetime().replace(tzinfo=timezone.utc)
+            expires_at = datetime.strptime(result['expires_at'], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
             seconds_till_expiry = (expires_at - datetime.utcnow().replace(tzinfo=timezone.utc)).seconds
             renew_after = max(0, seconds_till_expiry - 100)
             time.sleep(renew_after)

--- a/src/typegenie/lib.py
+++ b/src/typegenie/lib.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import List, Union
 
 from .api import AccountAPI, DeploymentAPI, UserAPI
-import pandas as pd
 import traceback
 
 
@@ -135,8 +134,8 @@ class Event:
         self._author = author.name
         self._event = event.name
         self._value = value
-        self._timestamp = timestamp if isinstance(timestamp, datetime) else pd.to_datetime(
-            timestamp).to_pydatetime().replace(tzinfo=timezone.utc)
+        self._timestamp = timestamp if isinstance(timestamp, datetime) else datetime.strptime(
+            timestamp, "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
 
     def to_dict(self):
         json = {
@@ -179,7 +178,8 @@ class DeploymentEvent:
         event = DeploymentEvent()
         event._dataset_ids = json['dataset_ids']
         event._configuration_id = json['configuration_id']
-        event._timestamp = pd.to_datetime(json['timestamp']).to_pydatetime().replace(tzinfo=timezone.utc)
+        event._timestamp = datetime.strptime(
+            json['timestamp'], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
         event._event = json['event']
         return event
 
@@ -238,7 +238,8 @@ class Dataset:
         dataset._metadata = metadata
         dataset._deployment_id = json['deployment_id']
         dataset._num_dialogues = json['num_dialogues']
-        dataset._created_at = pd.to_datetime(json['created_at']).to_pydatetime().replace(tzinfo=timezone.utc)
+        dataset._created_at = datetime.strptime(
+            json['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
         return dataset
 
     def delete(self):
@@ -374,7 +375,8 @@ class Deployment:
         deployment = Deployment()
         deployment._id = json['id']
         deployment._metadata = metadata
-        deployment._created_at = pd.to_datetime(json['created_at']).to_pydatetime().replace(tzinfo=timezone.utc)
+        deployment._created_at = datetime.strptime(
+            json['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
         return deployment
 
     @staticmethod
@@ -450,7 +452,8 @@ class User:
         user._id = json['id']
         user._metadata = metadata
         user._deployment_id = json['deployment_id']
-        user._created_at = pd.to_datetime(json['created_at']).to_pydatetime().replace(tzinfo=timezone.utc)
+        user._created_at = datetime.strptime(
+            json['created_at'], "%Y-%m-%dT%H:%M:%S.%fZ").replace(tzinfo=timezone.utc)
         return user
 
     def delete(self):


### PR DESCRIPTION
Use datetime instead to convert string to datetime object.

This is to eliminate a big dependency for a single small function.